### PR TITLE
Corrected version

### DIFF
--- a/Find-and-replace.sketchplugin/Contents/Sketch/manifest.json
+++ b/Find-and-replace.sketchplugin/Contents/Sketch/manifest.json
@@ -25,6 +25,6 @@
       "Find-and-replace"
     ]
   },
-  "version": "2.8.0",
+  "version": "2.8.2",
   "disableCocoaScriptPreprocessor": true
 }


### PR DESCRIPTION
s/2.8.0/2.8.2

Current manifest causes Sketch to update the plugin but still report it out of date.