### PR TITLE
Fix passing state containing regex with backslashes down to the webview

### DIFF
--- a/ressources/components/App.js
+++ b/ressources/components/App.js
@@ -65,7 +65,8 @@ export default class App extends React.Component {
   }
 
   componentDidMount() {
-    window.SetSettings = json => {
+    window.SetSettings = base64json => {
+      const json = decodeURIComponent(window.atob(base64json))
       this.setState(JSON.parse(json))
       this.findIntput.focus()
       this.setState({

--- a/ressources/index.js
+++ b/ressources/index.js
@@ -6,11 +6,11 @@ let dark = true
 
 window.settings = {}
 
-window.updateData = function(json) {
+window.updateData = function(base64json) {
   if (typeof window.SetSettings == 'function') {
-    window.SetSettings(json)
+    window.SetSettings(base64json)
   } else {
-    setTimeout(() => window.updateData(json), 100)
+    setTimeout(() => window.updateData(base64json), 100)
   }
 }
 

--- a/src/Find-and-replace.js
+++ b/src/Find-and-replace.js
@@ -207,9 +207,10 @@ export default function() {
       state = Object.assign({}, state, { init })
     }
     if (isWebviewPresent(windowOptions.identifier)) {
+      let base64EncodedState = Buffer.from(encodeURIComponent(JSON.stringify(state))).toString("base64")
       sendToWebview(
         windowOptions.identifier,
-        `updateData('${JSON.stringify(state)}')`
+        `updateData('${base64EncodedState}')`
       )
     }
     state = Object.assign({}, state, { init: false })


### PR DESCRIPTION
### Steps to Reproduce

1. Open the plugin, enable regex mode.
2. Using a regex with **at least one backslash** (e.g. `\((\d+)\)`), replace something successfully.
3. Open the plugin again.

### Expected Results

You see the same regex and all other settings you've just used on the previous step.

### Actual Results

- The plugin displays a loading screen for a few seconds, then switches to an empty state as if you've never used it before.
- The "Find in Selection" option is missing even if you, in fact, have something selected on the canvas. (#107)

------

### Explanation

We're currently passing `state` to the webview by converting it to a JS expression string to be evaluated.

This lead to special characters (e.g. backslashes) not being escaped properly in regular expressions (they need to be escaped twice for this to work) which, in turn, prevents the web app from parsing this JSON string back into an object.

### Solution

The solution is to pass the same stringified state but encoded it as base64 so we don't have to worry about escaping special characters and `JSON.parse()` throwing unhandled exceptions.


> [!NOTE]
> I'm attaching a pre-built version of the plugin with this fix applied so anyone can try it and see if it works for them 👇
> [Find-and-replace.sketchplugin-fix-for-regex.zip](https://github.com/thierryc/Sketch-Find-And-Replace/files/14112892/Find-and-replace.sketchplugin-fix-for-regex.zip)

> [!NOTE]
> An alternative workaround is [to reset the plugin settings](https://forum.sketch.com/t/does-anyone-know-a-reliable-plugin-for-find-and-replace-text/2314/16), although it won't prevent the issue from re-appearing again the next time you use regular expressions with backslashes to replace something.
